### PR TITLE
Interactive tracks performance improvements

### DIFF
--- a/napari/layers/tracks/_managers/_interactive_track_manager.py
+++ b/napari/layers/tracks/_managers/_interactive_track_manager.py
@@ -386,11 +386,11 @@ class InteractiveTrackManager(BaseTrackManager):
                 graph_vertices += [node.vertex, parent.vertex]
                 graph_connex += [True, False]
 
-        self._graph_vertices = np.array(graph_vertices)
-        self._graph_connex = np.array(graph_connex)
-        self._track_ids = np.array(track_ids)
-        self._track_vertices = np.array(vertices)
-        self._track_connex = np.array(connex)
+        self._graph_vertices = np.asarray(graph_vertices)
+        self._graph_connex = np.asarray(graph_connex)
+        self._track_ids = np.asarray(track_ids)
+        self._track_vertices = np.asarray(vertices)
+        self._track_connex = np.asarray(connex)
         self._features = pd.DataFrame(features) if has_features else None
         self._is_serialized = True
 
@@ -617,7 +617,7 @@ class InteractiveTrackManager(BaseTrackManager):
         features: Optional[pd.DataFrame] = None,
     ) -> Node:
         features = {} if features is None else features.to_dict()
-        node = Node(index=index, vertex=np.array(vertex), features=features)
+        node = Node(index=index, vertex=vertex, features=features)
         self._id_to_nodes[index] = node
 
         time = node.time
@@ -659,7 +659,9 @@ class InteractiveTrackManager(BaseTrackManager):
         self._validate_vertex_shape(vertex)
         self._max_node_index += 1
         node = self._add_node(
-            index=self._max_node_index, vertex=vertex, features=features
+            index=self._max_node_index,
+            vertex=np.asarray(vertex),
+            features=features,
         )
         self._leafs[node.index] = node
         return node.index
@@ -699,7 +701,7 @@ class InteractiveTrackManager(BaseTrackManager):
                         )
                     )
 
-            node.vertex = np.array(vertex)
+            node.vertex = np.asarray(vertex)
 
         if features is not None:
             if isinstance(features, pd.DataFrame):

--- a/napari/layers/tracks/_managers/_interactive_track_manager.py
+++ b/napari/layers/tracks/_managers/_interactive_track_manager.py
@@ -211,11 +211,9 @@ class InteractiveTrackManager(BaseTrackManager):
             track = track.sort_values('T')
             indices = track.index
             values = track.values
-            # iterating with range is much faster than using pandas `.iterrows`.
-            for i in range(len(indices)):
-                index = indices[i]
+            for index, val in zip(indices, values):
                 feats = None if features is None else features.iloc[index]
-                node = self._add_node(index, values[i, 1:], feats)
+                node = self._add_node(index, val[1:], feats)
 
                 if parent_node is not None:
                     parent_node.children.append(node)

--- a/napari/layers/tracks/_managers/_interactive_track_manager.py
+++ b/napari/layers/tracks/_managers/_interactive_track_manager.py
@@ -227,11 +227,6 @@ class InteractiveTrackManager(BaseTrackManager):
             self._leafs[node.index] = node
             track_to_leafs[track_id] = node
 
-        for time, time_subset in data.groupby('T', sort=False):
-            self._time_to_nodes[int(time)] = [
-                self._id_to_nodes[id] for id in time_subset.index
-            ]
-
         for track_id, parents in graph.items():
             node = track_to_roots[track_id]
             for parent_track_id in parents:
@@ -624,6 +619,12 @@ class InteractiveTrackManager(BaseTrackManager):
         features = {} if features is None else features.to_dict()
         node = Node(index, vertex, features)
         self._id_to_nodes[index] = node
+
+        time = node.time
+        if time not in self._time_to_nodes:
+            self._time_to_nodes[time] = []
+
+        self._time_to_nodes[time].append(node)
         return node
 
     def _validate_vertex_shape(self, vertex: np.ndarray) -> None:
@@ -661,12 +662,6 @@ class InteractiveTrackManager(BaseTrackManager):
             vertex=np.asarray(vertex),
             features=features,
         )
-        time = node.time
-        if time not in self._time_to_nodes:
-            self._time_to_nodes[time] = []
-
-        self._time_to_nodes[time].append(node)
-
         self._leafs[node.index] = node
         return node.index
 

--- a/napari/layers/tracks/_managers/_interactive_track_manager.py
+++ b/napari/layers/tracks/_managers/_interactive_track_manager.py
@@ -617,7 +617,7 @@ class InteractiveTrackManager(BaseTrackManager):
         features: Optional[pd.DataFrame] = None,
     ) -> Node:
         features = {} if features is None else features.to_dict()
-        node = Node(index=index, vertex=vertex, features=features)
+        node = Node(index, vertex, features)
         self._id_to_nodes[index] = node
 
         time = node.time

--- a/napari/layers/tracks/_managers/_interactive_track_manager.py
+++ b/napari/layers/tracks/_managers/_interactive_track_manager.py
@@ -227,6 +227,11 @@ class InteractiveTrackManager(BaseTrackManager):
             self._leafs[node.index] = node
             track_to_leafs[track_id] = node
 
+        for time, time_subset in data.groupby('T', sort=False):
+            self._time_to_nodes[int(time)] = [
+                self._id_to_nodes[id] for id in time_subset.index
+            ]
+
         for track_id, parents in graph.items():
             node = track_to_roots[track_id]
             for parent_track_id in parents:
@@ -619,13 +624,6 @@ class InteractiveTrackManager(BaseTrackManager):
         features = {} if features is None else features.to_dict()
         node = Node(index, vertex, features)
         self._id_to_nodes[index] = node
-
-        time = node.time
-        if time not in self._time_to_nodes:
-            self._time_to_nodes[time] = []
-
-        self._time_to_nodes[time].append(node)
-
         return node
 
     def _validate_vertex_shape(self, vertex: np.ndarray) -> None:
@@ -663,6 +661,12 @@ class InteractiveTrackManager(BaseTrackManager):
             vertex=np.asarray(vertex),
             features=features,
         )
+        time = node.time
+        if time not in self._time_to_nodes:
+            self._time_to_nodes[time] = []
+
+        self._time_to_nodes[time].append(node)
+
         self._leafs[node.index] = node
         return node.index
 


### PR DESCRIPTION
# Description

This PR proposes a few minor changes that improve the efficiency of `set_data` for the `InteractiveTrackManager`.

I ran the following benchmark command: `asv run --python=same -b time_interactive_manager`

Before changes proposed here:

```
[100.00%] ··· benchmark_tracks_manager.TrackManagerSuite.time_interactive_manager                                                                                                                                              [100.00%] ··· ========= ============= ============= ============= ============
              --                          sorted / n_tracks                   
              --------- ------------------------------------------------------
                 size     False / 10   False / 100    True / 10    True / 100 
              ========= ============= ============= ============= ============
                 100     2.43±0.08ms     11.4±2ms    2.39±0.05ms   9.76±0.3ms 
                 1000     5.40±0.1ms    18.7±0.2ms   5.42±0.06ms   18.7±0.3ms 
                10000     34.2±0.2ms    49.2±0.4ms    34.2±0.3ms   48.8±0.4ms 
                100000     354±3ms       355±2ms      346±0.7ms     345±3ms   
               1000000    3.73±0.03s    3.71±0.01s    3.46±0.01s    3.48±0s   
              ========= ============= ============= ============= ============
```


After changes proposed here all except a few of the size=100 cases are faster:
```
[100.00%] ··· benchmark_tracks_manager.TrackManagerSuite.time_interactive_manager                                                                                                                                              [100.00%] ··· ========= ============= ============= ============= =============
              --                           sorted / n_tracks                   
              --------- -------------------------------------------------------
                 size     False / 10   False / 100    True / 10     True / 100 
              ========= ============= ============= ============= =============
                 100     2.58±0.02ms    9.91±0.3ms   2.59±0.03ms    9.94±0.5ms 
                 1000    5.13±0.05ms   17.1±0.09ms    5.15±0.1ms    17.9±0.5ms 
                10000     31.2±0.8ms    39.4±0.5ms    29.5±0.3ms   38.9±0.07ms 
                100000     319±2ms       275±4ms       295±4ms       259±3ms   
               1000000    3.51±0.02s    2.91±0.01s    3.01±0.03s    2.53±0.01s 
              ========= ============= ============= ============= =============
```

I am not sure we want the change in d49fd51, though. If I revert that change you will see that performance is bit worse in some cases, but better in others. Result without d49fd51:

```
[100.00%] ··· benchmark_tracks_manager.TrackManagerSuite.time_interactive_manager
[100.00%] ··· ========= ============= ============= ============= ============
              --                          sorted / n_tracks                   
              --------- ------------------------------------------------------
                 size     False / 10   False / 100    True / 10    True / 100 
              ========= ============= ============= ============= ============
                 100     2.30±0.02ms    10.7±0.7ms   2.45±0.08ms   9.71±0.1ms 
                 1000     4.80±0.1ms    17.5±0.2ms   4.46±0.03ms   17.7±0.2ms 
                10000     26.5±0.2ms    41.6±0.3ms    25.5±0.3ms   40.4±0.2ms 
                100000     274±3ms       278±1ms       267±2ms      263±3ms   
               1000000    2.91±0.02s    2.93±0.02s     2.63±0s      2.71±0s   
              ========= ============= ============= ============= ============
```

