### PR TITLE
Fixes crash when adding point requiring buffer resize

### DIFF
--- a/napari/layers/graph/_tests/test_graph.py
+++ b/napari/layers/graph/_tests/test_graph.py
@@ -245,3 +245,17 @@ def test_graph_from_data_tuple_non_empty(graph_class: Type[BaseGraph]) -> None:
     assert layer.name == new_layer.name
     assert len(layer.data) == len(new_layer.data)
     assert layer.ndim == new_layer.ndim
+
+
+@pytest.mark.parametrize("graph_class", [UndirectedGraph, DirectedGraph])
+def test_add_nodes_buffer_resize(graph_class):
+    coords = np.asarray([(0, 0, 0)])
+
+    graph = graph_class(coords=coords)
+    layer = Graph(graph, out_of_slice_display=True)
+
+    # adding will cause buffer to resize
+    layer.add([(1, 1, 1)])
+    assert len(layer.data) == coords.shape[0] + 1
+    assert graph.n_nodes == coords.shape[0] + 1
+

--- a/napari/layers/graph/graph.py
+++ b/napari/layers/graph/graph.py
@@ -488,18 +488,19 @@ class Graph(_BasePoints):
                 self._border._add(n_colors=adding)
                 self._face._update_current_properties(current_properties)
                 self._face._add(n_colors=adding)
-
-                # `shown` must be first due to "refresh" calls inside `attribute`.setters
-                for attribute in ("shown", "size", "symbol", "border_width"):
-                    if attribute == "shown":
-                        default_value = True
-                    else:
-                        default_value = getattr(self, f"current_{attribute}")
-                    new_values = np.repeat([default_value], adding, axis=0)
-                    values = np.concatenate(
-                        (getattr(self, f"_{attribute}"), new_values), axis=0
-                    )
-                    setattr(self, attribute, values)
+                
+                # ensure each attribute is updated before refreshing
+                with self._block_refresh():
+                    for attribute in ("shown", "size", "symbol", "border_width"):
+                        if attribute == "shown":
+                            default_value = True
+                        else:
+                            default_value = getattr(self, f"current_{attribute}")
+                        new_values = np.repeat([default_value], adding, axis=0)
+                        values = np.concatenate(
+                            (getattr(self, f"_{attribute}"), new_values), axis=0
+                        )
+                        setattr(self, attribute, values)
 
     def _data_changed(self, prev_size: int) -> None:
         self._update_props_and_style(self.data.n_allocated_nodes, prev_size)
@@ -511,3 +512,4 @@ class Graph(_BasePoints):
         state.pop("properties", None)
         state.pop("property_choices", None)
         return state
+    


### PR DESCRIPTION
Fixes error thrown when adding points to graph layer by adding refresh blocker, as suggested [here](https://github.com/napari/napari/pull/5861/files/ea2ac8c9364855cfff62a5692aab7f214ddd95bc#r1336217787).

## Type of change
<!-- Please delete options that are not relevant. -->
- [X] Bug-fix (non-breaking change which fixes an issue)

# How has this been tested?
I have included a test that fails without the fix and passes with the fix. the test adds points to a graph layer

## Final checklist:
- [X] My PR is the minimum possible work for the desired functionality
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
