### PR TITLE
fix VispyGraphLayer _subvisuals error

### DIFF
--- a/napari/_vispy/layers/graph.py
+++ b/napari/_vispy/layers/graph.py
@@ -5,7 +5,7 @@ from napari._vispy.visuals.graph import GraphVisual
 
 
 class VispyGraphLayer(VispyPointsLayer):
-    _visual = GraphVisual
+    node = GraphVisual
 
     def _on_data_change(self) -> None:
         self._set_graph_edges_data()

--- a/napari/_vispy/layers/graph.py
+++ b/napari/_vispy/layers/graph.py
@@ -5,7 +5,8 @@ from napari._vispy.visuals.graph import GraphVisual
 
 
 class VispyGraphLayer(VispyPointsLayer):
-    node = GraphVisual
+    _visual = GraphVisual
+    node: GraphVisual
 
     def _on_data_change(self) -> None:
         self._set_graph_edges_data()

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -11,10 +11,11 @@ from napari.utils.events import disconnect_events
 
 
 class VispyPointsLayer(VispyBaseLayer):
-    node = PointsVisual
+    _visual = PointsVisual
+    node: PointVisual
 
     def __init__(self, layer) -> None:
-        node = self.node()
+        node = self._visual()
         super().__init__(layer, node)
 
         self.layer.events.symbol.connect(self._on_data_change)

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -14,7 +14,7 @@ class VispyPointsLayer(VispyBaseLayer):
     node: PointsVisual
 
     def __init__(self, layer) -> None:
-        node = PointsVisual()
+        node = self.node()
         super().__init__(layer, node)
 
         self.layer.events.symbol.connect(self._on_data_change)

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -11,7 +11,7 @@ from napari.utils.events import disconnect_events
 
 
 class VispyPointsLayer(VispyBaseLayer):
-    node: PointsVisual
+    node = PointsVisual
 
     def __init__(self, layer) -> None:
         node = self.node()


### PR DESCRIPTION
# Description
Using the current state of the branch, running the `examples/add_graph.py` will lead to this:

```python
File "/napari/napari/_vispy/layers/graph.py", line 16, in _set_graph_edges_data
    subvisual = self.node._subvisuals[4]
IndexError: list index out of range
```

This is due to the creation of the `node` from the super class `VispyPointsLayer`
https://github.com/JoOkuma/napari/blob/6c21fc8421f973257e3c0bbe3434950a2d641aed/napari/_vispy/layers/points.py#L17-L18

Here I propose to use the already existing `VispyPointsLayer.node` attribute in `VispyGraphLayer` to correctly extend the `node._subvisuals`
